### PR TITLE
ユーザー詳細ページの実装２

### DIFF
--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%=link_to prototype.user.name, root_path, class: :card_user %>
+    <%=link_to prototype.user.name, user_path(prototype.user_id), class: :card_user %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,7 @@
         <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: 'prototypes/prototype', collection: @user.prototypes %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# What
マイページの実装
①トップページのユーザー名をクリックするとマイページに遷移できる。
②マイページにてユーザーが登録したプロトタイプが表示される。

# Why
マイページを実装するため。

# Gyazo GIF
https://gyazo.com/da1ef7bfe59bdfabbbf68ec0ce7d742b
https://gyazo.com/2e09c721b3f59542bf05c5dfd7a5b599
