### PR TITLE
詳細ページの各ユーザー名にパスを記述

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to  "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%= link_to  "by #{@prototype.user.name}", user_path(@prototype.user_id), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
@@ -49,7 +49,7 @@
           <% @comments.each do |comment|%>
             <li class="comments_list">
               <%= comment.content%>
-              <%= link_to comment.user.name, root_path, class: :comment_user %>
+              <%= link_to comment.user.name, user_path(comment.user_id), class: :comment_user %>
             </li>
           <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>


### PR DESCRIPTION
# What
各ユーザー名にパスを記述した。
①プロトタイプ詳細ページのプロトタイプ投稿者の部分から、ユーザー詳細ページへ遷移
②各コメントの投稿者の部分から、ユーザー詳細ページへ遷移

# Why
各ユーザー名からそれぞれのユーザー詳細ページへ遷移するため。

# Gyazo GIF
①https://gyazo.com/9f44b56d4ee079e4076d5a66b401b6b1
②https://gyazo.com/511662298a2e417a9d952cf1f9da0935